### PR TITLE
add functionality to use all the available GPUs if needed, passing "-g -1" key number

### DIFF
--- a/deephub/trainer/__main__.py
+++ b/deephub/trainer/__main__.py
@@ -117,7 +117,7 @@ def train(variant_name, variants_dir, gpu_device_ids, extra_expr_params, extra_s
 
     # avoid passing "-1" with the regular arguments.
     if len(gpu_device_ids) == 1 and gpu_device_ids[0] == -1:
-        gpu_device_ids = tuple(find_idle_gpu_devices())
+        gpu_device_ids = find_idle_gpu_devices()
         trainer = Trainer(requested_gpu_devices=gpu_device_ids)
     else:
         trainer = Trainer(requested_gpu_devices=gpu_device_ids)

--- a/deephub/trainer/__main__.py
+++ b/deephub/trainer/__main__.py
@@ -1,6 +1,7 @@
 import click
 
 from deephub.trainer import Trainer
+from deephub.trainer.utils import find_idle_gpu_devices
 from deephub.variants.io import (load_variant, UnknownVariant)
 
 
@@ -114,7 +115,12 @@ def train(variant_name, variants_dir, gpu_device_ids, extra_expr_params, extra_s
         variant_definition.set('train.warm_start_check_point', warm_start_checkpoint)
         variant_definition.set('train.warm_start_variables_regex', warm_start_vars)
 
-    trainer = Trainer(requested_gpu_devices=gpu_device_ids)
+    # avoid passing "-1" with the regular arguments.
+    if len(gpu_device_ids) == 1 and gpu_device_ids[0] == -1:
+        gpu_device_ids = tuple(find_idle_gpu_devices())
+        trainer = Trainer(requested_gpu_devices=gpu_device_ids)
+    else:
+        trainer = Trainer(requested_gpu_devices=gpu_device_ids)
     click.echo("Starting model training.")
 
     variant_definition.train(trainer=trainer)


### PR DESCRIPTION
In case of kubernetes deployment, the GPUs allocation should be done by the k8s master, 
so passing **" -1 "** as gpu selection, means: "use all the available GPUs in the system", with actual meaning: "use all the GPUs that the user has specified in the k8s-deployment yaml".